### PR TITLE
Fix SETTINGS_MODULE None when using override_settings in tests

### DIFF
--- a/pimpmytheme/templatetags/pimptheme.py
+++ b/pimpmytheme/templatetags/pimptheme.py
@@ -7,7 +7,11 @@ from django.utils.safestring import mark_safe
 from django.contrib.staticfiles import finders
 from django.templatetags.static import static
 register = template.Library()
-project_name = settings.SETTINGS_MODULE.split(".")[0]
+
+try:
+    project_name = settings.SETTINGS_MODULE.split(".")[0]
+except AttributeError:
+    project_name = settings.default_settings.SETTINGS_MODULE.split(".")[0]
 
 
 def pimp(context, file_type, filename=None):


### PR DESCRIPTION
This code fixes the case when we override a setting in django tests.
If the first test that is importing the templatetag module and is loaded in a settings_override decorator or context block, then the `SETTINGS_MODULE` will defined to `None` but the original value is still available through the `default_settings` attribute.