### PR TITLE
Upgrade django-compressor, add tests for django 1.11

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+# .coveragerc
+[report]
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ db.sqlite3
 .coverage
 .tox
 example/example/static/
+.idea

--- a/pimpmytheme/filters.py
+++ b/pimpmytheme/filters.py
@@ -8,17 +8,11 @@ from compressor.filters.css_default import CssAbsoluteFilter, SCHEMES
 
 class PrefixedCssAbsoluteFilter(CssAbsoluteFilter):
 
-    def _converter(self, matchobj, group, template):
-        url = matchobj.group(group)
-
-        url = url.strip()
-        wrap = '"' if url[0] == '"' else "'"
-        url = url.strip('\'"')
-
-        if url.startswith('#'):
-            return template % (wrap, url, wrap)
+    def _converter(self, url):
+        if url.startswith(('#', 'data:')):
+            return url
         elif url.startswith(SCHEMES):
-            return template % (wrap, self.add_suffix(url), wrap)
+            return self.add_suffix(url)
         full_url = posixpath.normpath('/'.join([str(self.directory_name),
                                                 url]))
 
@@ -37,4 +31,5 @@ class PrefixedCssAbsoluteFilter(CssAbsoluteFilter):
 
         if self.has_scheme:
             full_url = "%s%s" % (self.protocol, full_url)
-        return template % (wrap, self.add_suffix(full_url), wrap)
+        full_url = self.add_suffix(full_url)
+        return self.post_process_url(full_url)

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ NAME = 'django-pimpmytheme'
 DESCRIPTION = ("Customise theme (css and template) on a per user/client "
                "whatever basis")
 REQUIREMENTS = [
-    'Django>=1.8,<1.11',
-    'django-compressor>=2.1.1',
+    'Django>=1.8,<2.0',
+    'django-compressor>=2.2',
     'gitpython>1.0.0',
 ]
 __VERSION__ = read_relative_file('VERSION').strip()
@@ -56,6 +56,12 @@ params = dict(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = flake8,py{27,34,35}-django{18,19,110}
+envlist = flake8,py{27,34,35}-django{18,19,110,111}
 
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     django-nose
     coverage
     gitpython


### PR DESCRIPTION
Upgrade django-compressor to 2.2, fix PrefixedCssAbsoluteFilter._converter signature accordingly
Confirm Django 1.11 support
Show missing lines in test coverage
Improve library classifiers